### PR TITLE
Remove CHECK macros to support multiple calls

### DIFF
--- a/nanopb_comparators.cpp
+++ b/nanopb_comparators.cpp
@@ -58,13 +58,6 @@ bool NanopbStructComparator::isEqual(const void *object1, const void *object2) {
   sFatPointer expected_encoded = prv_encode_pb_dynamic(object1, this->fields);
   sFatPointer actual_encoded = prv_encode_pb_dynamic(object2, this->fields);
 
-  // These macros provide more helpful error messages than simply returning false upon mismatch
-  LONGS_EQUAL_TEXT(expected_encoded.size, actual_encoded.size,
-                   "Encoded protobuf size did not match expectations");
-  MEMCMP_EQUAL_TEXT(expected_encoded.ptr, actual_encoded.ptr, expected_encoded.size,
-                    "Encoded protobuf data did not match expectations");
-
-  // Technically redundant since the macros above should immediately fail the test
   bool is_equal = (expected_encoded.size == actual_encoded.size) &&
                   !memcmp(expected_encoded.ptr, actual_encoded.ptr, expected_encoded.size);
 


### PR DESCRIPTION
If a comparator for a type is used multiple times in the same unit test,
CppUTest will use the comparator to see if an actual call matches _any_
of the given expected calls. In this case, it's expected that some
checks using the comparator may return false even if the test should
succeed.

Using `CHECK` macros within the comparator causes the whole unit test to
fail immediately, which goes against the expectation of CppUTest.

This PR removes these macros and simply returns a boolean indicating
whether a check succeeded.

Credit to nickgraham@google.com for discovering and fixing the issue.